### PR TITLE
add a 'do' for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ end
 defmodule SomePythonCall do
   use Export.Python
 
-  def call_python_method
+  def call_python_method do
     # path to our python files
     {:ok, py} = Python.start(python_path: Path.expand("lib/python"))
 


### PR DESCRIPTION
Just add a "do" for call_python_method function in  README.md. Maybe another function in Ruby also need it.