### PR TITLE
Elixir 1.7 and OTP 21 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: elixir
 elixir:
   - 1.2
+  - 1.6
+  - 1.7
 otp_release:
   - 18.2
+  - 20.3
+  - 21.0
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: elixir
 elixir:
-  - 1.2
+  - 1.4
   - 1.6
   - 1.7
 otp_release:
   - 18.2
   - 20.3
   - 21.0
+matrix:
+  exclude:
+  - elixir: 1.4
+    otp_release: 21.0
 sudo: false

--- a/lib/export/helpers.ex
+++ b/lib/export/helpers.ex
@@ -6,10 +6,10 @@ defmodule Export.Helpers do
       case opt do
         {key, other_options} when other_options |> is_list ->
           {key, other_options |> Enum.map(fn ({key, value}) ->
-            {key |> Atom.to_char_list, value |> String.to_char_list}
+            {key |> Atom.to_charlist, value |> String.to_charlist}
           end)}
         {key, value} when value |> is_bitstring ->
-          {key, value |> String.to_char_list}
+          {key, value |> String.to_charlist}
         _ -> opt
       end
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Export.Mixfile do
 
   defp deps() do
     [
-      {:erlport, "~> 0.9"},
+      {:erlport, "~> 0.10"},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "erlport": {:hex, :erlport, "0.9.8", "b7dc57eb87f215a671926bfbcd23e6e9c76f8653b0d072627b41431ef51c4d20", [:rebar3], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{
+  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+  "erlport": {:hex, :erlport, "0.10.0", "2436ec2f4ed62538c6e9c52f523f9315b6002ee7e298d9bd10b35abc3f6b32e7", [:rebar3], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+}


### PR DESCRIPTION
This bumps the erlport dependency to version 0.10 which supports OTP 21. Also fixes a couple depreciation warnings and adds some versions to the travis config.